### PR TITLE
Rename variables of Google Analytics script

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,10 +12,10 @@
 
 
     <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    !function(E,s,n,e,x,t){E.GoogleAnalyticsObject=e,E[e]||(E[e]=function(){
+    (E[e].q=E[e].q||[]).push(arguments)}),E[e].l=+new Date,x=s.createElement(n),
+    t=s.getElementsByTagName(n)[0],x.src='//www.google-analytics.com/analytics.js',
+    t.parentNode.insertBefore(x,t)}(window,document,'script','ga');
 
     ga('create', 'UA-53521505-1', 'auto');
     ga('send', 'pageview');


### PR DESCRIPTION
`i` `s` `o` `g` `r` `a` `m` -> `E` `s` `n` `e` `x` `t`

It is generated by [isogram](https://github.com/shinnn/isogram), a GA script generator used by [gulp website](https://github.com/gulpjs/gulpjs.github.io/blob/fc2a237ef4b476dd9428fce0da77c6bd3f8b925d/index.html#L134).
